### PR TITLE
Fix bug in sourcemap table

### DIFF
--- a/lib/errmap.lua
+++ b/lib/errmap.lua
@@ -24,16 +24,19 @@ local match = string.match
 local tonumber = tonumber
 
 --- generate error string with source mapping table
+--- @param label string
+--- @param srcmap table
+--- @param err string
 --- @return string err
-local function errmap(label, tags, err)
+local function errmap(label, srcmap, err)
     if type(label) ~= 'string' then
         error('label must be string', 2)
     elseif type(err) ~= 'string' then
         error('err must be string', 2)
-    elseif tags == nil then
+    elseif srcmap == nil then
         return err
-    elseif type(tags) ~= 'table' then
-        error('tags must be table', 2)
+    elseif type(srcmap) ~= 'table' then
+        error('srcmap must be table', 2)
     end
 
     -- find error position
@@ -50,12 +53,12 @@ local function errmap(label, tags, err)
     --  - and, logic code...
     --
     idx = tonumber(idx, 10) - 1
-    local tag = tags[idx]
+    local tag = srcmap[idx]
     if not tag then
         return err
     end
 
-    return format('invalid tag at [%q]:%d:%d: %s', label, tag.lineno,
+    return format('invalid tag %q at [%q]:%d:%d: %s', tag.op, label, tag.lineno,
                   tag.linecol, msg)
 end
 

--- a/rez.lua
+++ b/rez.lua
@@ -106,13 +106,13 @@ local function render(rez, name)
         if ok then
             data[ctx.layout.varname] = concat(res)
         else
-            data[ctx.layout.varname] = errmap(name, target.tags, res)
+            data[ctx.layout.varname] = errmap(name, target.srcmap, res)
         end
         return render(rez, ctx.layout.name)
     end
 
     if not ok then
-        return nil, errmap(name, target.tags, res)
+        return nil, errmap(name, target.srcmap, res)
     end
 
     return concat(res)

--- a/test/rez_test.lua
+++ b/test/rez_test.lua
@@ -608,3 +608,27 @@ function testcase.syntax_tokenize()
         assert.match(err, format('illegal bracket token %q', sym_close))
     end
 end
+
+function testcase.compile_error()
+    local r = rez.new()
+
+    -- test that compile error
+    local ok, err = r:add('parse', [[
+        {{ hello }}
+        {{?
+            local foo = 1
+
+            local bar = 2
+
+        }}
+        {{for
+            k,
+            v = pairs(baz)
+        }}
+            {{ world }}
+        {{/for}}
+    ]])
+    assert.is_false(ok)
+    assert.match(err, 'invalid tag "for" at ["parse"]:8')
+end
+


### PR DESCRIPTION
unable to locate the error line if an expression containing a newline.